### PR TITLE
Update logic.lua

### DIFF
--- a/scripts/logic.lua
+++ b/scripts/logic.lua
@@ -365,7 +365,7 @@ end
 
 function pewter()
     return (
-        oldman() or flypewter() or flycerulean() or flyvermillion()
+        oldman() or flypewter() or (flycerulean() and cancut()) or (flyvermillion() and cancut())
         or ((flylavender() or flyceladon()) and (guard() or (cancut() and canflash()) or (boulders() and pokeflute())))
         or (flyfuchsia() and ((pokeflute() and (bike() or boulders())) or cansurf()) and (guard() or (cancut() and canflash()) or (boulders() and pokeflute())))
         or (canstrength() and cansurf() and (guard() or (cancut() and canflash())))


### PR DESCRIPTION
This adds logic to remove the ledge near Pewter. A lot of AP versions ago there was a ledge leading from Digletts Cave to Pewter so softlocks could be prevented. When the "Pallet Warp" got added, they reverted the ledge back to a Cut Tree but the poptracker pack never got this change.